### PR TITLE
Fixed JSON for Requests

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -122,7 +122,7 @@ function parseRequest(request) {
     host: url.host,
     hostname: url.hostname,
     href: url.href,
-    json: async (maxSize) => JSON.parse(getBodyText(maxSize)),
+    json: async (maxSize) => JSON.parse(await getBodyText(maxSize)),
     method: request.method,
     origin: `${url.protocol}//${url.host}`,
     path: url.pathname,


### PR DESCRIPTION
Hey there,
I'm trying to get  JSON from the request but that doesn't work, it always tells me: "SyntaxError: Unexpected token o in JSON at position 1"

After some lookups in your code, I figured out this line:
https://github.com/markusahlstrand/cloudworker-router/blob/42ef8ed1b340c72bbba5db100bc0671f2832beb6/src/parser.js#L125
is missing an await and should reather be:
`json: async (maxSize) => JSON.parse(await getBodyText(maxSize))`

I hope that you can implement this and I can help some people