### PR TITLE
Removed redundant decodeURIComponent

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -131,9 +131,6 @@ function parseRequest(request) {
     querystring: url.search.slice(1),
     search: url.search,
     text: async (maxSize) => {
-      if (request.headers.get('content-type') === 'application/x-www-form-urlencoded') {
-        return decodeURIComponent(await getBodyText(maxSize));
-      }
       return getBodyText(maxSize);
     },
   };


### PR DESCRIPTION
`request.text()` isn't supposed to do any manipulation on the body, just read the stream and return it as string.
This kind of manipulation belongs to a higher place in the code.
For example, the following code cannot work due to this redundant decoding:
```
  const qs = require('querystring');
  // ...
  const text = await request.text()
  const data = qs.parse(text)
```

If the body is a submitted url-encoded form, and one of the field values contains ampersand, the original body will look like this:
`field1=some+value&field2=some+value+&#38;+some+more`
The result of `qs.parse` in this case will be
```
{
  field1: "some value",
  field2: "some value",
  "some more": ""
}
```

instead of 
```
{
  field1: "some value",
  field2: "some value & some more"
}
```