### PR TITLE
feat: change handle signature for worker modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Cloudworker Router V2
+# Cloudworker Router V3
+
+With V3 of the router we now support wrangler V2 module, which required a change of the handle function signature.
 
 This is a rewrite of the v1 router based on the [tiny-request-router](https://www.npmjs.com/package/tiny-request-router) that does the heavy lifting.
 
@@ -34,9 +36,11 @@ router.get('/', async (ctx) => {
   return new Response('Hello World');
 });
 
-addEventListener('fetch', (event) => {
-  event.respondWith(router.resolve(event));
-});
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return router.handle(reuquest, env, ctx);
+  },
+};
 ```
 
 The router exposes get, post, patch and del methods as shorthands for the most common use cases. For examples of their usage, see the example folder. HEAD requests are handled automatically by the router.
@@ -94,16 +98,37 @@ An example of a context object created for a request:
 ```js
 {
   request: Request,
-  event: {
-    request: Request,
-    type: "fetch"
-  },
+  event: ExecutionContext
   state: {},
   query: {
     foo: "bar"
   },
   params: {}
+  env: {}
 }
+```
+
+### Env
+
+The Router is generic class that makes it possible to get strictly typed env.
+
+```js
+const Router = require('cloudworker-router');
+
+interface MyEnv {
+  test: string;
+}
+const router = new Router<MyEnv>();
+
+router.get('/', async (ctx) => {
+  return new Response(ctx.env.test);
+});
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return router.handle(reuquest, env, ctx);
+  },
+};
 ```
 
 ### Allow headers

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudworker-router",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "A router for cloudflare workers",
   "files": [
     "dist/src/**/*"

--- a/src/types/Context.ts
+++ b/src/types/Context.ts
@@ -1,6 +1,6 @@
 import { Params } from './Params';
 
-export type Context = {
+export type Context<Env = { [key: string]: string | DurableObjectNamespace | KVNamespace }> = {
   request: Request;
   params: Params;
   query: URLSearchParams;
@@ -9,6 +9,6 @@ export type Context = {
   // To keep state for the current request
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   state: { [key: string]: any };
-  // The raw event
-  event: FetchEvent & { env?: { [key: string]: string | DurableObjectNamespace | KVNamespace } };
+  env: Env;
+  event: ExecutionContext;
 };


### PR DESCRIPTION
The worker modules work a bit differently so it needed a slightly bigger breaking change.

More info on the migration here: https://developers.cloudflare.com/workers/learning/migrating-to-module-workers/